### PR TITLE
parallel optimisation via openmp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,16 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|Intel")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
+
 if (TARGET tbb)
   add_definitions(-DRGB2SPEC_USE_TBB=1)
   include_directories(${TBB_INCLUDE_DIRS})
+else ()
+  include(FindOpenMP)
+  if(OPENMP_FOUND)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+  endif()
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/rgb2spec_opt.cpp
+++ b/rgb2spec_opt.cpp
@@ -260,8 +260,11 @@ int main(int argc, char **argv) {
     size_t bufsize = 3*3*res*res*res;
     float *out = new float[bufsize];
 
+#if defined(_OPENMP)
+#pragma omp parallel for collapse(2) default(none) schedule(dynamic) shared(stdout,scale,out)
+#endif
     for (int l = 0; l < 3; ++l) {
-#if defined(RGB2SPEC_USE_TBB)
+#if !defined(_OPENMP) && defined(RGB2SPEC_USE_TBB)
         tbb::parallel_for(0, res, [&](size_t j) {
 
 #else


### PR DESCRIPTION
this does not depend on external libraries for parallelisation, only on the compiler feature.

i currently wrote it such that it takes precedence over tbb (if openmp is found we'll use this no matter what), i guess that choice is up for discussion (someone might want to give tbb explicitly and overrule openmp, which they currently can't).

i parallelised both loops (over the three quads and the pixels therein), i hope i didn't miss any data dependencies there.