### PR TITLE
Fallback for non x86/x64 architectures

### DIFF
--- a/rgb2spec.c
+++ b/rgb2spec.c
@@ -134,9 +134,15 @@ float rgb2spec_eval_precise(float coeff[RGB2SPEC_N_COEFFS], float lambda) {
 }
 
 float rgb2spec_eval_fast(float coeff[RGB2SPEC_N_COEFFS], float lambda) {
-    float x = rgb2spec_fma(rgb2spec_fma(coeff[0], lambda, coeff[1]), lambda, coeff[2]),
-          y = _mm_cvtss_f32(_mm_rsqrt_ss(_mm_set_ss(rgb2spec_fma(x, x, 1.f))));
-    return rgb2spec_fma(.5f * x, y, .5f);
+    #if defined(__x86_64__)
+        float x = rgb2spec_fma(rgb2spec_fma(coeff[0], lambda, coeff[1]), lambda, coeff[2]),
+              y = _mm_cvtss_f32(_mm_rsqrt_ss(_mm_set_ss(rgb2spec_fma(x, x, 1.f))));
+        return rgb2spec_fma(.5f * x, y, .5f);
+    #else
+        // Fallback for other architectures:
+        return rgb2spec_eval_precise(coeff, lambda);
+    #endif
+
 }
 
 #if defined(__SSE4_2__)

--- a/rgb2spec.h
+++ b/rgb2spec.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <stdint.h>
-#include <immintrin.h>
+
+#if defined(__x86_64__)
+    #include <immintrin.h>
+#endif
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
Compilation failed on Apple M2 due to `#include <immintrin.h>` and the functions `_mm_cvtss_f32()`, `_mm_rsqrt_ss()` and `_mm_set_ss()`.

This fix adds a fallback to bypass the optimization used in `rgb2spec_eval_fast()`.