### PR TITLE
Declare res as shared for OpenMP.

### DIFF
--- a/rgb2spec_opt.cpp
+++ b/rgb2spec_opt.cpp
@@ -295,7 +295,7 @@ int main(int argc, char **argv) {
     float *out = new float[bufsize];
 
 #if defined(RGB2SPEC_USE_OPENMP)
-#  pragma omp parallel for collapse(2) default(none) schedule(dynamic) shared(stdout,scale,out)
+#  pragma omp parallel for collapse(2) default(none) schedule(dynamic) shared(stdout,scale,out,res)
 #endif
     for (int l = 0; l < 3; ++l) {
 #if defined(RGB2SPEC_USE_TBB)


### PR DESCRIPTION
The variable `res` (which is read-only within the parallel-for) needs to be declared as shared to OpenMP. Without it, it fails to compile:

```bash
$ clang++ -O3 -fopenmp -DRGB2SPEC_USE_OPENMP rgb2spec_opt.cpp
rgb2spec_opt.cpp:306:29: error: variable 'res' must have explicitly specified data sharing attributes
  306 |         for (int j = 0; j < res; ++j) {
      |                             ^~~
rgb2spec_opt.cpp:298:48: note: explicit data sharing attribute requested here
  298 | #  pragma omp parallel for collapse(2) default(none) schedule(dynamic) shared(stdout,scale,out)
      |                                                ^
...
```